### PR TITLE
74 create real control plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,6 @@
 	path = src/realsense-ros
 	url = https://github.com/IntelRealSense/realsense-ros.git
 	branch = ros2-master
+[submodule "src/cobot_hardware"]
+	path = src/cobot_hardware
+	url = https://gitlab.hs-esslingen.de/rharbach/cobot_hardware.git


### PR DESCRIPTION
Add cobot_hardware as submodule to this repo.

It is hosted on the HS-Esslingen GitLab and can only be cloned when connected to their VPN