### PR TITLE
Create custom MoveItControllerManager 

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get install -y ros-jazzy-ros2-control ros-jazzy-ros2-controllers
 # install Gazebo Hamonic ROS2 control
 RUN apt-get install -y ros-jazzy-gz-ros2-control
 # install Moveit2
-RUN apt-get install -y ros-jazzy-moveit ros-jazzy-moveit-py
+RUN apt-get install -y ros-jazzy-moveit ros-jazzy-moveit-py ros-jazzy-moveit-ros-control-interface
 RUN apt-get install -y ros-jazzy-moveit-visual-tools
 # install panda config (for reference purposes)
 RUN apt-get install -y ros-jazzy-moveit-resources-panda-moveit-config

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,3 +9,4 @@
 [submodule "src/cobot_hardware"]
 	path = src/cobot_hardware
 	url = https://gitlab.hs-esslingen.de/rharbach/cobot_hardware.git
+	branch = adapt-hw-interface-to-custom-controller-manager

--- a/src/cobot_controller_manager/CMakeLists.txt
+++ b/src/cobot_controller_manager/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required(VERSION 3.10)
+project(cobot_controller_manager)
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(moveit_core REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(trajectory_msgs REQUIRED)
+find_package(rclcpp_action REQUIRED)
+find_package(control_msgs REQUIRED)
+
+add_library(cobot_controller_manager SHARED
+  src/cobot_controller_manager.cpp
+)
+
+target_include_directories(cobot_controller_manager PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
+ament_target_dependencies(cobot_controller_manager
+  rclcpp
+  pluginlib
+  moveit_core
+  trajectory_msgs
+  moveit_core
+  rclcpp_action
+  control_msgs
+)
+
+pluginlib_export_plugin_description_file(moveit_core cobot_controller_plugins.xml)
+
+
+install(TARGETS cobot_controller_manager
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(DIRECTORY include/
+  DESTINATION include
+)
+
+install(FILES cobot_controller_plugins.xml
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()

--- a/src/cobot_controller_manager/cobot_controller_plugins.xml
+++ b/src/cobot_controller_manager/cobot_controller_plugins.xml
@@ -1,0 +1,6 @@
+<library path="cobot_controller_manager">
+  <class 
+        name="cobot_controller_manager/CobotControllerManager"
+        type="cobot_controller_manager::CobotControllerManager"
+        base_class_type="moveit_controller_manager::MoveItControllerManager"/>
+</library>

--- a/src/cobot_controller_manager/include/cobot_controller_manager/single_point_trajectory_controller_handle.hpp
+++ b/src/cobot_controller_manager/include/cobot_controller_manager/single_point_trajectory_controller_handle.hpp
@@ -1,0 +1,141 @@
+/*********************************************************************
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2025, Robert Harbach
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#pragma once
+
+#include <string>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
+#include <control_msgs/action/follow_joint_trajectory.hpp>
+#include <moveit/controller_manager/controller_manager.hpp>
+
+namespace cobot_controller_manager
+{
+
+  /*
+   * A TrajectoryControllerHandle that sends out only the last trajectory point.
+   */
+  class SinglePointTrajectoryControllerHandle : public moveit_controller_manager::MoveItControllerHandle
+  {
+  public:
+    SinglePointTrajectoryControllerHandle(const std::string &name,
+                                          const std::string &topic_name,
+                                          const rclcpp::Node::SharedPtr &node)
+        : moveit_controller_manager::MoveItControllerHandle(name),
+          topic_name_(topic_name),
+          node_(node)
+    {
+      // create action client
+      auto action_name = "/arm_group_controller/follow_joint_trajectory"; // TODO @rharbach: figure out a way to avoid hard coded values
+      controller_action_client_ = rclcpp_action::create_client<control_msgs::action::FollowJointTrajectory>(node_, action_name);
+      if (!controller_action_client_->wait_for_action_server(std::chrono::seconds(5)))
+      {
+        RCLCPP_ERROR(node_->get_logger(), "Could not find action server within 5 seconds");
+        return;
+      }
+    }
+
+    /*
+     * Fill the trajectory and send it to the action sever.
+     * Since our hardware interface accepts only one trajectory point,
+     * we send out the last trajectory point.
+     *
+     * Args:
+     *  trajectory: the trajectory to be send to the action server
+     *
+     * Returns: true if action server received trajectory, false otherwise.
+     */
+    bool sendTrajectory(const moveit_msgs::msg::RobotTrajectory &trajectory) override
+    {
+      if (trajectory.joint_trajectory.points.empty())
+      {
+        RCLCPP_ERROR(node_->get_logger(), "Received an empty trajectory.");
+        return false;
+      }
+
+      // prepare trajectory. We are sending out ONE single point of the entire trajectory
+      auto goal_msg = control_msgs::action::FollowJointTrajectory::Goal();
+      goal_msg.trajectory.header.stamp = rclcpp::Time(0);
+      goal_msg.trajectory.joint_names = trajectory.joint_trajectory.joint_names;
+      // use last point only
+      auto last_trajectory_point = trajectory.joint_trajectory.points.back();
+      // this module -> ROS2 controller -> cobot_hardware
+      // since the ROS2 controller interpolates between trajectory points and hence, generates another trajectory,
+      // we need to tell it that there is no need for trajectory generation by setting the time from start to 0.
+      last_trajectory_point.time_from_start = rclcpp::Duration(0, 0);
+      goal_msg.trajectory.points.push_back(last_trajectory_point);
+
+      // send goal to ROS2 controller
+      auto current_goal_future = controller_action_client_->async_send_goal(goal_msg);
+
+      if (!current_goal_future.get())
+      {
+        RCLCPP_ERROR(node_->get_logger(), "Goal was rejected by server");
+        return false;
+      }
+      return true;
+    }
+
+    /*
+     * Cancel the current trajectory execution.
+     * Our trajectory's last point is forwarded via ROS2 control directly to the hw interface.
+     * => Implementation not required.
+     */
+    bool cancelExecution() override
+    {
+      RCLCPP_ERROR(node_->get_logger(), "cancelExecution() is not implemented");
+      return true;
+    }
+
+    /*
+     * Wait for the execution to complete. Implementation not required.
+     */
+    bool waitForExecution(const rclcpp::Duration &timeout) override
+    {
+      RCLCPP_ERROR(node_->get_logger(), "waitForExecution() is not implemented");
+      return true;
+    }
+
+    /*
+     * Wait for the execution to complete. Implementation not required.
+     */
+    moveit_controller_manager::ExecutionStatus getLastExecutionStatus() override
+    {
+      return moveit_controller_manager::ExecutionStatus::SUCCEEDED;
+    }
+
+  private:
+    std::string topic_name_;
+    rclcpp::Node::SharedPtr node_;
+    rclcpp_action::Client<control_msgs::action::FollowJointTrajectory>::SharedPtr controller_action_client_;
+  };
+
+} // namespace cobot_controller_manager

--- a/src/cobot_controller_manager/package.xml
+++ b/src/cobot_controller_manager/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>cobot_controller_manager</name>
+  <version>1.0.0</version>
+  <description>Custom MoveIt Controller Manager and Controller Handle for Single Point Trajectory forwarding.</description>
+  <maintainer email="robgineer@gmail.com">Robert Harbach</maintainer>
+
+  <license>BSD-3-Clause</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rclcpp_action</depend>
+  <depend>moveit_core</depend>
+  <depend>pluginlib</depend>
+  <depend>trajectory_msgs</depend>
+  <depend>moveit_msgs</depend>
+  <depend>control_msgs</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+    <pluginlib plugin="${prefix}/cobot_controller_plugins.xml"/>
+  </export>
+
+</package>

--- a/src/cobot_controller_manager/src/cobot_controller_manager.cpp
+++ b/src/cobot_controller_manager/src/cobot_controller_manager.cpp
@@ -1,0 +1,160 @@
+/*********************************************************************
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2025, Robert Harbach
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <string>
+#include <rclcpp/rclcpp.hpp>
+#include <pluginlib/class_list_macros.hpp>
+#include <trajectory_msgs/msg/joint_trajectory.hpp>
+#include <moveit/controller_manager/controller_manager.hpp>
+
+#include "cobot_controller_manager/single_point_trajectory_controller_handle.hpp"
+
+namespace cobot_controller_manager
+{
+
+  class CobotControllerManager : public moveit_controller_manager::MoveItControllerManager
+  {
+  public:
+    CobotControllerManager() {}
+
+    ~CobotControllerManager() override = default;
+
+    /*
+     * Define controllers, joints and create SinglePointTrajectoryControllerHandle.
+     */
+    void initialize(const rclcpp::Node::SharedPtr &node)
+    {
+      node_ = node;
+      // TODO @robgineer: do not use hard coded values here
+      // identify all parameters from the node
+      std::string controller_name = "arm_group_controller";
+      std::vector<std::string> joints = {
+          "joint_0", "joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6"};
+
+      auto handle = std::make_shared<SinglePointTrajectoryControllerHandle>(
+          controller_name, "/joint_trajectory_controller/command", node_);
+      // set controller and joints
+      controllers_[controller_name] = handle;
+      controller_joints_[controller_name] = joints;
+      // TODO @robgineer: extend this for the grippers
+    }
+
+    moveit_controller_manager::MoveItControllerHandlePtr getControllerHandle(const std::string &name) override
+    {
+      return controllers_.at(name);
+    }
+
+    /*
+     * Provide the list of controllers present.
+     *
+     * Args:
+     *  names: string vector of names to be filled
+     */
+    void getControllersList(std::vector<std::string> &names) override
+    {
+      for (const auto &it : controllers_)
+      {
+        names.push_back(it.first);
+      }
+    }
+
+    /*
+     * Return active controllers. Since there are no inactive controllers, we simply
+     * list all controllers.
+     *
+     * Args:
+     *  names: string vector of names to be filled
+     */
+    void getActiveControllers(std::vector<std::string> &names) override
+    {
+      getControllersList(names);
+    }
+
+    /*
+     * By default all controllers are loaded.
+     * Calling getControllersList
+     *
+     * TODO @robgineer: might not be required.
+     *
+     * Args:
+     *  names: string vector of names to be filled
+     */
+    virtual void getLoadedControllers(std::vector<std::string> &names)
+    {
+      getControllersList(names);
+    }
+
+    /*
+     * Return the list of joints for a given controller name
+     *
+     * Args:
+     *  name: name of controller
+     *  joints: string vector of joints to be filled
+     */
+    void getControllerJoints(const std::string &name, std::vector<std::string> &joints) override
+    {
+      joints = controller_joints_.at(name);
+    }
+
+    /*
+     * Returns the controller state.
+     * We expect the controllers to be always active.
+     */
+    moveit_controller_manager::MoveItControllerManager::ControllerState
+    getControllerState(const std::string & /*name*/) override
+    {
+      moveit_controller_manager::MoveItControllerManager::ControllerState state;
+      state.active_ = true;
+      state.default_ = true;
+      return state;
+    }
+
+    /*
+     * Switch controllers.
+     * Not required and hence, not implemented.
+     */
+    bool switchControllers(const std::vector<std::string> & /*activate*/,
+                           const std::vector<std::string> & /*deactivate*/) override
+    {
+      return false;
+    }
+
+  protected:
+    rclcpp::Node::SharedPtr node_;
+    std::map<std::string, std::vector<std::string>> controller_joints_;
+    std::map<std::string, moveit_controller_manager::MoveItControllerHandlePtr> controllers_;
+  };
+
+} // namespace cobot_controller_manager
+
+// register the plugin
+PLUGINLIB_EXPORT_CLASS(cobot_controller_manager::CobotControllerManager,
+                       moveit_controller_manager::MoveItControllerManager)

--- a/src/cobot_moveit_config/config/moveit_custom_controllers.yaml
+++ b/src/cobot_moveit_config/config/moveit_custom_controllers.yaml
@@ -1,0 +1,34 @@
+moveit_controller_manager: cobot_controller_manager/CobotControllerManage
+
+cobot_controller_manager:
+  controller_names:
+    - arm_group_controller
+    - gripper_group_controller
+    - vacuum_gripper_group_controller
+
+  arm_group_controller:
+    action_ns: follow_joint_trajectory
+    type: FollowJointTrajectory
+    default: true
+    joints:
+      - joint_0
+      - joint_1
+      - joint_2
+      - joint_3
+      - joint_4
+      - joint_5
+      - joint_6
+
+  gripper_group_controller:
+    action_ns: gripper_cmd
+    type: GripperCommand
+    default: true
+    joints:
+      - finger1_joint
+
+  vacuum_gripper_group_controller:
+    action_ns: gripper_cmd
+    type: GripperCommand
+    default: true
+    joints:
+      - vacuum_up_joint

--- a/src/cobot_moveit_config/config/moveit_custom_controllers.yaml
+++ b/src/cobot_moveit_config/config/moveit_custom_controllers.yaml
@@ -1,4 +1,4 @@
-moveit_controller_manager: cobot_controller_manager/CobotControllerManage
+moveit_controller_manager: cobot_controller_manager/CobotControllerManager
 
 cobot_controller_manager:
   controller_names:


### PR DESCRIPTION
The current implementation allowed the control of the robot via ROS2 / Moveit2 with the following limitation:
MoveIt2 send out trajectories which are used for real time control. ROS2 takes these and forwards them to the hw interface.

Since our cobot does not accept trajectories (but single points as it has its own motion control), we wait in the hw interface until we receive the last trajectory point. This implies a delay and a user unfriendly handling.

This PR introduces a custom MoveIt Controller Manager and Controller Handle that sends out one single point to ros2_control.

This way, MoveIt2 would plan a trajectory but send out only its last point to the robot and get rid of the delay in trajectory execution and increase usability.

Open Points

- [x] Adapt ```moveit_controllers.yaml```
- [x] Test ```moveit_controllers.yaml``` / ```moveit_custom_controllers.yaml``` on robot
- [x] Adapt ```launch file```
- [x] Update the submodule to main branch once the PR is merged on the HS Esslingen GitLab