### PR TITLE
Forward entire trajectories to cobot hardware interface

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get install -y ros-jazzy-ros2-control ros-jazzy-ros2-controllers
 # install Gazebo Hamonic ROS2 control
 RUN apt-get install -y ros-jazzy-gz-ros2-control
 # install Moveit2
-RUN apt-get install -y ros-jazzy-moveit ros-jazzy-moveit-py ros-jazzy-moveit-ros-control-interface
+RUN apt-get install -y ros-jazzy-moveit ros-jazzy-moveit-py ros-jazzy-moveit-ros-control-interface ros-jazzy-control-msgs
 RUN apt-get install -y ros-jazzy-moveit-visual-tools
 # install panda config (for reference purposes)
 RUN apt-get install -y ros-jazzy-moveit-resources-panda-moveit-config

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 [submodule "src/cobot_hardware"]
 	path = src/cobot_hardware
 	url = https://gitlab.hs-esslingen.de/rharbach/cobot_hardware.git
-	branch = adapt-hw-interface-to-custom-controller-manager
+	branch = implement-full-trajectory-hw-interface

--- a/src/cobot_controller_manager/README.md
+++ b/src/cobot_controller_manager/README.md
@@ -1,0 +1,39 @@
+# Cobot Controller Manager
+
+## Discontinued 
+
+This solution is currently not active in the Cobot project. It has been replaced by a custom trajectory controller. To reactivate this solution, revert commit: 9a403d50ed45b9cc583237b94f2c068a97f4bd74 and use the following branch for the `cobot_hardware`: `adapt-hw-interface-to-custom-controller-manager`.
+
+### Reason 
+Although this solution results in smooth movements of the Cobot arm, the resulting trajectory is calculated by the SPS of the Cobot. We therefore have no influence on the trajectory and collisions that were considered within trajectory planning are obsolete. Hence, even with a camera attached, the Cobot will be blind with this solution.
+
+## Implementation Overview
+
+Our Cobot is not able to follow a full trajectory. It instead accepts the final trajectory point or a list of points (in form of a path). MoveIt2 and ROS2 control, however are designed to generate a trajectory and send out single position / velocity / effort commands to the hardware in realtime. Since we cannot use these single points, we use the last trajectory point and forward it to the Cobot hardware interface. 
+
+
+### Communication Flow
+```
+cobot_controller_manager (this package)
+        ↓ (send last trajectory point)
+ros2_control controller
+        ↓ (forward one single point to hardware interface)
+cobot_hardware (real hardware interface)
+```
+
+## Getting started
+
+This controller manager works only in combination with the `cobot_hardware` package (branch: `adapt-hw-interface-to-custom-controller-manager`) and aims to control the real Cobot.
+
+In order to manipulate the Cobot in ROS2, connect to HS-Esslingen VPN and run
+```
+git clone https://github.com/robgineer/cobot.git .
+git submodule init src/cobot_hardware
+git submodule update src/cobot_hardware
+```
+Then build this project and run
+```
+ros2 launch demo rviz_demo_launch.py controller_type:=real
+```
+
+

--- a/src/cobot_moveit_config/config/festo_cobot_model.srdf
+++ b/src/cobot_moveit_config/config/festo_cobot_model.srdf
@@ -13,12 +13,12 @@
         <chain base_link="base_link" tip_link="TCP"/>
     </group>
     <group_state group="arm_group" name="balancer_mode">
-    <joint name="joint_0" value="0.155"/>
-    <joint name="joint_1" value="-1.57"/>
-    <joint name="joint_2" value="0.610865"/>
-    <joint name="joint_3" value="-0.785398"/>
-    <joint name="joint_4" value="1.57"/>
-    <joint name="joint_5" value="-1.57"/>
+    <joint name="joint_0" value="0.156"/>
+    <joint name="joint_1" value="-1.56"/>
+    <joint name="joint_2" value="0.61"/>
+    <joint name="joint_3" value="-0.777"/>
+    <joint name="joint_4" value="1.56"/>
+    <joint name="joint_5" value="-1.56"/>
     <joint name="joint_6" value="-0.4"/>
   </group_state>
 

--- a/src/cobot_moveit_config/config/moveit_custom_controllers.yaml
+++ b/src/cobot_moveit_config/config/moveit_custom_controllers.yaml
@@ -1,12 +1,12 @@
-moveit_controller_manager: cobot_controller_manager/CobotControllerManage
+moveit_controller_manager: moveit_simple_controller_manager/MoveItSimpleControllerManager
 
-cobot_controller_manager:
+moveit_simple_controller_manager:
   controller_names:
-    - arm_group_controller
+    - cobot_arm_group_controller
     - gripper_group_controller
     - vacuum_gripper_group_controller
 
-  arm_group_controller:
+  cobot_arm_group_controller:
     action_ns: follow_joint_trajectory
     type: FollowJointTrajectory
     default: true

--- a/src/cobot_moveit_config/config/ros2_controllers.yaml
+++ b/src/cobot_moveit_config/config/ros2_controllers.yaml
@@ -5,7 +5,10 @@ controller_manager:
 
     arm_group_controller:
       type: joint_trajectory_controller/JointTrajectoryController
-    
+
+    cobot_arm_group_controller:
+      type: cobot_trajectory_controller/CobotTrajectoryController
+
     gripper_group_controller:
       type: position_controllers/GripperActionController
 
@@ -31,6 +34,22 @@ arm_group_controller:
       - position
       - velocity
 
+cobot_arm_group_controller:
+  ros__parameters:
+    joints:
+      - joint_0
+      - joint_1
+      - joint_2
+      - joint_3
+      - joint_4
+      - joint_5
+      - joint_6
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+      - velocity
+
 gripper_group_controller:
   ros__parameters:
     joint: finger1_joint
@@ -38,5 +57,3 @@ gripper_group_controller:
 vacuum_gripper_group_controller:
    ros__parameters:
     joint: vacuum_up_joint
-
-

--- a/src/cobot_trajectory_controller/CMakeLists.txt
+++ b/src/cobot_trajectory_controller/CMakeLists.txt
@@ -1,0 +1,53 @@
+cmake_minimum_required(VERSION 3.8)
+project(cobot_trajectory_controller)
+
+set(CMAKE_CXX_STANDARD 14)
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(controller_interface REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(realtime_tools REQUIRED)
+find_package(trajectory_msgs REQUIRED)
+find_package(cobot_hardware REQUIRED)
+
+include_directories(
+  include
+)
+add_library(${PROJECT_NAME} SHARED
+  src/cobot_trajectory_controller.cpp
+)
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+ament_target_dependencies(${PROJECT_NAME}
+  rclcpp
+  controller_interface
+  pluginlib
+  realtime_tools
+  trajectory_msgs
+  cobot_hardware
+)
+pluginlib_export_plugin_description_file(controller_interface cobot_trajectory_controller_plugins.xml)
+
+
+install(
+  DIRECTORY include/
+  DESTINATION include/
+)
+
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(
+  FILES cobot_trajectory_controller_plugins.xml
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()

--- a/src/cobot_trajectory_controller/README.md
+++ b/src/cobot_trajectory_controller/README.md
@@ -1,0 +1,59 @@
+# Cobot Trajectory Controller
+
+Custom ROS2 controller for the Cobot.
+
+## Getting started
+
+This controller works only in combination with the `cobot_hardware` package and aims to control the real Cobot.
+
+In order to manipulate the Cobot in ROS2, connect to HS-Esslingen VPN and run
+```
+git clone https://github.com/robgineer/cobot.git .
+git submodule init src/cobot_hardware
+git submodule update src/cobot_hardware
+```
+Then build this project and run
+```
+ros2 launch demo rviz_demo_launch.py controller_type:=real
+```
+
+## Implementation Overview
+
+We have two options to pass commands to the Cobot: single point (the final point of a trajectory, via ```SetRobotWaypoint```) or a list of points (via ```ExecuteInstructionList```, representing a path). We cannot send actual trajectories or fine grained position commands as the SPS of the Cobot takes care of the trajectory (and we cannot by-pass the SPS).
+
+This, unfortunately, does not align with the ROS2 control principles. A basic overview of the trajectory generation and control is provided in the following:
+```
+MoveIt Planning (OMPL) → Generates a collision free path
+                ↓
+Time Parameterization Plugin (Iterative / TOTG) → Adds time (making it an actual trajectory)
+                ↓
+Final RobotTrajectory message
+                ↓
+MoveIt Simple Controller Manager
+                ↓
+ros2_control controller
+                ↓
+HardwareInterface (this package)
+```
+The ROS2 controllers are designed to send position commands to the hardware in real time; which is not suitable for the Cobot. 
+
+In previous implementations, we simply sent the final trajectory point to the Cobot (using a custom MoveItControllerManager, *the CobotControllerManager*). Although this resulted in smooth movements of the Cobot arm, the resulting trajectory was calculated by the SPS. We therefore had no influence on the trajectory and collisions that were considered within trajectory planning were obsolete. Hence, even with a camera attached, the Cobot would have been blind.
+
+In order to overcome this limitation we use the instruction list mechanism, where we pass a list of points to the Cobot and since the standard implementation of the ROS2 trajectory controller does not allow to send full trajectories (or lists of points), we are using this custom ROS2 controller, that send out either the last point of a trajectory or the entire trajectory to this interface.
+Note: ROS2 control implies using single joint commands (declared as double) and since a full trajectory was therefore difficult to be passed, we introduced another communication feature: a singleton realtime buffer.
+
+```
+MoveIt Planning (OMPL) → Generates a collision free path
+        ↓
+Time Parameterization Plugin (Iterative / TOTG) → Adds time (making it an actual trajectory)
+        ↓
+Final RobotTrajectory message
+        ↓
+MoveIt Simple Controller Manager
+        ↓
+cobot_trajectory_controller (this package)
+        ↓ trajectory (via shared buffer)
+cobot_hardware
+```
+
+

--- a/src/cobot_trajectory_controller/cobot_trajectory_controller_plugins.xml
+++ b/src/cobot_trajectory_controller/cobot_trajectory_controller_plugins.xml
@@ -1,0 +1,8 @@
+<library path="cobot_trajectory_controller">
+  <class
+      name="cobot_trajectory_controller/CobotTrajectoryController"
+      type="cobot_trajectory_controller::CobotTrajectoryController"
+      base_class_type="controller_interface::ControllerInterface">
+    <description>A custom ROS2 controller that publishes either the last point of a trajectory or a full path to the hardware interface</description>
+  </class>
+</library>

--- a/src/cobot_trajectory_controller/include/cobot_trajectory_controller/cobot_trajectory_controller.hpp
+++ b/src/cobot_trajectory_controller/include/cobot_trajectory_controller/cobot_trajectory_controller.hpp
@@ -46,11 +46,11 @@ namespace cobot_trajectory_controller
    * Implementation of a JointTrajectoryController tailored for the Cobot.
    * Unlike the standard implementation this controller does not use real time
    * joint commands (command interfaces) for the control of the hardware.
-   * Instead, it accepts a trajectory and passes either its last point or 
+   * Instead, it accepts a trajectory and passes either its last point or
    * the entire trajectory to the hardware interface using a real time buffer (singleton).
    * Rationale: the Cobot to be controlled does not accept single commands for trajectory
    * execution but either the final trajectory point or a list of trajectory points.
-   * 
+   *
    * Sending one point or the entire trajectory is configured using the parameter "execution_mode",
    * which enables on demand changes of the trajectory execution.
    *

--- a/src/cobot_trajectory_controller/include/cobot_trajectory_controller/cobot_trajectory_controller.hpp
+++ b/src/cobot_trajectory_controller/include/cobot_trajectory_controller/cobot_trajectory_controller.hpp
@@ -1,0 +1,139 @@
+/*********************************************************************
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2025, Robert Harbach
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <rclcpp/logger.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
+#include <realtime_tools/realtime_buffer.hpp>
+#include <trajectory_msgs/msg/joint_trajectory.hpp>
+#include <controller_interface/controller_interface.hpp>
+#include <control_msgs/action/follow_joint_trajectory.hpp>
+
+namespace cobot_trajectory_controller
+{
+  /*
+   * Implementation of a JointTrajectoryController tailored for the Cobot.
+   * Unlike the standard implementation this controller does not use real time
+   * joint commands (command interfaces) for the control of the hardware.
+   * Instead, it accepts a trajectory and passes either its last point or 
+   * the entire trajectory to the hardware interface using a real time buffer (singleton).
+   * Rationale: the Cobot to be controlled does not accept single commands for trajectory
+   * execution but either the final trajectory point or a list of trajectory points.
+   * 
+   * Sending one point or the entire trajectory is configured using the parameter "execution_mode",
+   * which enables on demand changes of the trajectory execution.
+   *
+   * Note: the usage of a singleton buffer might violate some ROS2 control principles but
+   * it is an acceptable tradeoff. Without it we would either need to send complex
+   * data structures through the as double declared CommandInterfaces (via reinterpret_cast)
+   * or implement a custom CommandInterfaces that can be handled by the ROS2 control manager.
+   */
+  class CobotTrajectoryController : public controller_interface::ControllerInterface
+  {
+  public:
+    CobotTrajectoryController();
+
+    /*
+     * Expose the command interfaces to the controller manager
+     */
+    controller_interface::InterfaceConfiguration command_interface_configuration() const override;
+    /*
+     * Expose the state interfaces to the controller manager
+     */
+    controller_interface::InterfaceConfiguration state_interface_configuration() const override;
+    /*
+     * Configure ROS2 environment: get parameter values, initialise action server, etc.
+     */
+    controller_interface::CallbackReturn on_configure(const rclcpp_lifecycle::State &previous_state) override;
+    /*
+     * Cleanup
+     */
+    controller_interface::CallbackReturn on_deactivate(const rclcpp_lifecycle::State &previous_state) override;
+    /*
+     * Communication with the hardware interface. Fills a realtime buffer with a trajectory for the hardware interface.
+     */
+    controller_interface::return_type update(const rclcpp::Time &time, const rclcpp::Duration &period) override;
+    // not required pure virtual functions
+    controller_interface::CallbackReturn on_init() override;
+    controller_interface::CallbackReturn on_activate(const rclcpp_lifecycle::State &previous_state) override;
+
+  private:
+    using FollowJointTrajectory = control_msgs::action::FollowJointTrajectory;
+    using ServerGoalHandle = rclcpp_action::ServerGoalHandle<FollowJointTrajectory>;
+    /*
+     * Called once new trajectory is sent from MoveIt to the running action server.
+     * This function fills the internal_trajectory_buffer_.
+     * The reason behind using an internal buffer is the asynchronous execution of the callback.
+     * It is executed once a new trajectory is available and hence runs in parallel to the update
+     * function of this controller. In order to avoid race conditions, we write the trajectory into
+     * an internal buffer and read it within the update function in real time.
+     */
+    rclcpp_action::GoalResponse goal_callback(
+        const rclcpp_action::GoalUUID &uuid, std::shared_ptr<const FollowJointTrajectory::Goal> goal);
+    /*
+     * Implementation is not required. We do not react on cancellations (the Cobot API does not contain a cancel implementation)
+     * and hence we simply return with rclcpp_action::CancelResponse:ACCEPT.
+     */
+    rclcpp_action::CancelResponse cancel_callback(
+        const std::shared_ptr<ServerGoalHandle> goal_handle);
+    /*
+     * Implementation is not required. We do not do anything special within the scope of a trajectory execution and hence
+     * we simply set the goal handle to "succeeded".
+     */
+    void accepted_callback(
+        const std::shared_ptr<ServerGoalHandle> goal_handle);
+    /*
+     * Helper function. Resamples trajectory to reduce the number of points.
+     * Args:
+     *  trajectory: the trajectory to be resampled
+     * Returns:
+     *  resampled trajectory
+     */
+    trajectory_msgs::msg::JointTrajectory resample_trajectory(const trajectory_msgs::msg::JointTrajectory &trajectory);
+    // Logger of this node (to avoid calling get_node()->get_logger() frequently)
+    std::unique_ptr<rclcpp::Logger> local_logger_;
+    // Define if only the last point or the full trajectory will be send to the hardware interface
+    std::string execution_mode_ = "single_point";
+    // Action server for the trajectory. Communicates with MoveIt2 and executes the callbacks declared above.
+    rclcpp_action::Server<FollowJointTrajectory>::SharedPtr trajectory_action_server_;
+    // Names of joints to be claimed in this controller
+    std::vector<std::string> joint_names_;
+    using JointTrajectory = trajectory_msgs::msg::JointTrajectory;
+    // Internal buffer. Filled once a new trajectory has been sent to the action server
+    realtime_tools::RealtimeBuffer<std::optional<JointTrajectory>> internal_trajectory_buffer_;
+    // External buffer (singleton). Filled in case a new trajectory is available. Consumed by the hardware interface.
+    std::shared_ptr<realtime_tools::RealtimeBuffer<std::optional<JointTrajectory>>> external_trajectory_buffer_;
+  };
+
+} // namespace cobot_trajectory_controller

--- a/src/cobot_trajectory_controller/package.xml
+++ b/src/cobot_trajectory_controller/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>cobot_trajectory_controller</name>
+  <version>1.0.0</version>
+  <description>A custom ROS2 controller that publishes either the last point of a trajectory or a full path to the hardware interface.</description>
+  <maintainer email="robgineer@gmail.com">Robert Harbach</maintainer>
+  <maintainer email="Robert.Harbach@hs-esslingen.de">Robert Harbach</maintainer>
+
+  <license>BSD-3-Clause</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>controller_interface</depend>
+  <depend>pluginlib</depend>
+  <depend>trajectory_msgs</depend>
+  <depend>realtime_tools</depend>
+  <depend>cobot_hardware</depend>
+
+  <export>
+    <pluginlib plugin="${prefix}/cobot_trajectory_controller_plugins.xml"/>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/cobot_trajectory_controller/src/cobot_trajectory_controller.cpp
+++ b/src/cobot_trajectory_controller/src/cobot_trajectory_controller.cpp
@@ -1,0 +1,190 @@
+/*********************************************************************
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2025, Robert Harbach
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+
+#include <pluginlib/class_list_macros.hpp>
+
+#include "cobot_hardware/shared_trajectory_buffer.hpp"
+#include "cobot_trajectory_controller/cobot_trajectory_controller.hpp"
+
+namespace cobot_trajectory_controller
+{
+
+  CobotTrajectoryController::CobotTrajectoryController() {}
+
+  controller_interface::InterfaceConfiguration CobotTrajectoryController::command_interface_configuration() const
+  {
+    // Claim all joints for this controller; so MoveIt and ROS2 are satisfied.
+    // The actual command is send in form of the full trajectory to the hardware interface.
+    // We use the singleton buffer (external_trajectory_buffer_) for this. Refer update function.
+    controller_interface::InterfaceConfiguration command_interface_configuration;
+    command_interface_configuration.type = controller_interface::interface_configuration_type::INDIVIDUAL;
+    for (const auto &joint : joint_names_)
+    {
+      command_interface_configuration.names.push_back(joint + "/position");
+    }
+    return command_interface_configuration;
+  }
+
+  controller_interface::InterfaceConfiguration CobotTrajectoryController::state_interface_configuration() const
+  {
+    // Register this controller as the updater for the state of each joint.
+    // This enables the ROS2 control manager to publish the state of the Cobot by reading
+    // the state interfaces provided in the hardware interface.
+    controller_interface::InterfaceConfiguration state_interface_configuration;
+    state_interface_configuration.type = controller_interface::interface_configuration_type::INDIVIDUAL;
+    for (const auto &joint : joint_names_)
+    {
+      state_interface_configuration.names.push_back(joint + "/position");
+      state_interface_configuration.names.push_back(joint + "/velocity");
+    }
+    return state_interface_configuration;
+  }
+
+  controller_interface::CallbackReturn CobotTrajectoryController::on_configure(const rclcpp_lifecycle::State &)
+  {
+    local_logger_ = std::make_unique<rclcpp::Logger>(get_node()->get_logger());
+    // create action server and register callbacks
+    trajectory_action_server_ = rclcpp_action::create_server<FollowJointTrajectory>(
+        get_node()->get_node_base_interface(),
+        get_node()->get_node_clock_interface(),
+        get_node()->get_node_logging_interface(),
+        get_node()->get_node_waitables_interface(),
+        std::string(get_node()->get_name()) + "/follow_joint_trajectory", // the trajectory we are looking for
+        std::bind(&CobotTrajectoryController::goal_callback, this, std::placeholders::_1, std::placeholders::_2),
+        std::bind(&CobotTrajectoryController::cancel_callback, this, std::placeholders::_1),
+        std::bind(&CobotTrajectoryController::accepted_callback, this, std::placeholders::_1));
+    
+    // get the joint names from the URDF
+    get_node()->declare_parameter<std::vector<std::string>>("joints", std::vector<std::string>{});
+    if (!get_node()->get_parameter("joints", joint_names_))
+    {
+      RCLCPP_ERROR(*local_logger_, "Parameter 'joints' not set");
+      return controller_interface::CallbackReturn::ERROR;
+    }
+    // initialise the singleton buffer
+    // TODO @rharbach: think of error handling
+    external_trajectory_buffer_ = SharedTrajectoryBuffer::getTrajectoryBuffer();
+    // declare the execution mode
+     get_node()->declare_parameter<std::string>("execution_mode", execution_mode_);
+
+    return controller_interface::CallbackReturn::SUCCESS;
+  }
+
+  controller_interface::CallbackReturn CobotTrajectoryController::on_deactivate(const rclcpp_lifecycle::State &)
+  {
+    // reset internal and external buffer
+    internal_trajectory_buffer_.writeFromNonRT(std::nullopt);
+    external_trajectory_buffer_->writeFromNonRT(std::nullopt);
+
+    return controller_interface::CallbackReturn::SUCCESS;
+  }
+
+  controller_interface::return_type CobotTrajectoryController::update(const rclcpp::Time &, const rclcpp::Duration &)
+  {
+    // get current trajectory
+    auto full_trajectory = internal_trajectory_buffer_.readFromRT();
+    // proceed only in case new trajectory is available
+    if (full_trajectory && full_trajectory->has_value())
+    {
+      // handle execution modes
+      get_node()->get_parameter("execution_mode", execution_mode_);
+      if (execution_mode_ == "full_trajectory"){
+        // we need to reduce the number of points of the trajectory so the 
+        // hardware interface can handle the list execution
+        auto resampled_trajectory = resample_trajectory(full_trajectory->value());
+        external_trajectory_buffer_->writeFromNonRT(resampled_trajectory);
+      }
+      else if(execution_mode_ == "single_point"){
+        trajectory_msgs::msg::JointTrajectory single_point_trajectory;
+        single_point_trajectory.header.stamp = full_trajectory->value().header.stamp;
+        single_point_trajectory.joint_names = full_trajectory->value().joint_names;
+        // use last point only
+        auto last_trajectory_point = full_trajectory->value().points.back();
+        single_point_trajectory.points.push_back(last_trajectory_point);
+        external_trajectory_buffer_->writeFromNonRT(single_point_trajectory);
+      }
+      else {
+        RCLCPP_ERROR(*local_logger_, "Invalid execution mode. Set execution_mode parameter to single_point or full_trajectory and reset controller.");
+          return controller_interface::return_type::ERROR;
+      }
+
+      // reset the buffer
+      internal_trajectory_buffer_.writeFromNonRT(std::nullopt);
+    }
+
+    return controller_interface::return_type::OK;
+  }
+
+  rclcpp_action::GoalResponse CobotTrajectoryController::goal_callback(const rclcpp_action::GoalUUID &, std::shared_ptr<const FollowJointTrajectory::Goal> goal)
+  {
+    internal_trajectory_buffer_.writeFromNonRT(goal->trajectory);
+    return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
+  }
+
+  trajectory_msgs::msg::JointTrajectory CobotTrajectoryController::resample_trajectory(const trajectory_msgs::msg::JointTrajectory &trajectory)
+  {
+    // TODO @rharbach: implement a more complex approach using linear interpolation
+    const auto kUseEveryNthTrajectoryPoint = 20;
+    trajectory_msgs::msg::JointTrajectory resampled_trajectory;
+    for (size_t i = 0; i <= trajectory.points.size(); i++) {
+       if(i % kUseEveryNthTrajectoryPoint == 0){
+        resampled_trajectory.points.push_back(trajectory.points[i]);
+       }
+    }
+    return resampled_trajectory;
+  }
+
+  controller_interface::CallbackReturn CobotTrajectoryController::on_init()
+  {
+    // not required and hence not implemented
+    return controller_interface::CallbackReturn::SUCCESS;
+  }
+  controller_interface::CallbackReturn CobotTrajectoryController::on_activate(const rclcpp_lifecycle::State &)
+  {
+    // not required and hence not implemented
+    return controller_interface::CallbackReturn::SUCCESS;
+  }
+  rclcpp_action::CancelResponse CobotTrajectoryController::cancel_callback(const std::shared_ptr<ServerGoalHandle> goal_handle)
+  {
+    // not required and hence not implemented
+    goal_handle->canceled(std::make_shared<FollowJointTrajectory::Result>());
+    return rclcpp_action::CancelResponse::ACCEPT;
+  }
+  void CobotTrajectoryController::accepted_callback(const std::shared_ptr<ServerGoalHandle> goal_handle)
+  {
+    // not required and hence not implemented
+    goal_handle->succeed(std::make_shared<FollowJointTrajectory::Result>());
+  }
+
+} // namespace cobot_trajectory_controller
+
+PLUGINLIB_EXPORT_CLASS(cobot_trajectory_controller::CobotTrajectoryController, controller_interface::ControllerInterface)

--- a/src/cobot_trajectory_controller/src/cobot_trajectory_controller.cpp
+++ b/src/cobot_trajectory_controller/src/cobot_trajectory_controller.cpp
@@ -153,10 +153,14 @@ namespace cobot_trajectory_controller
   trajectory_msgs::msg::JointTrajectory CobotTrajectoryController::resample_trajectory(const trajectory_msgs::msg::JointTrajectory &trajectory)
   {
     // TODO @rharbach: implement a more complex approach using linear interpolation
-    const auto kUseEveryNthTrajectoryPoint = 20;
+    const auto kUseEveryNthTrajectoryPoint = 10;
     trajectory_msgs::msg::JointTrajectory resampled_trajectory;
-    for (size_t i = 0; i <= trajectory.points.size(); i++) {
-       if(i % kUseEveryNthTrajectoryPoint == 0){
+    for (size_t i = 0; i < trajectory.points.size(); i++) {
+      if (i ==  trajectory.points.size() - 1) {
+        // always add last point
+         resampled_trajectory.points.push_back(trajectory.points[i]);
+      }
+      else if(i % kUseEveryNthTrajectoryPoint == 0){
         resampled_trajectory.points.push_back(trajectory.points[i]);
        }
     }

--- a/src/cobot_trajectory_controller/src/cobot_trajectory_controller.cpp
+++ b/src/cobot_trajectory_controller/src/cobot_trajectory_controller.cpp
@@ -29,7 +29,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-
 #include <pluginlib/class_list_macros.hpp>
 
 #include "cobot_hardware/shared_trajectory_buffer.hpp"
@@ -82,7 +81,7 @@ namespace cobot_trajectory_controller
         std::bind(&CobotTrajectoryController::goal_callback, this, std::placeholders::_1, std::placeholders::_2),
         std::bind(&CobotTrajectoryController::cancel_callback, this, std::placeholders::_1),
         std::bind(&CobotTrajectoryController::accepted_callback, this, std::placeholders::_1));
-    
+
     // get the joint names from the URDF
     get_node()->declare_parameter<std::vector<std::string>>("joints", std::vector<std::string>{});
     if (!get_node()->get_parameter("joints", joint_names_))
@@ -94,7 +93,7 @@ namespace cobot_trajectory_controller
     // TODO @rharbach: think of error handling
     external_trajectory_buffer_ = SharedTrajectoryBuffer::getTrajectoryBuffer();
     // declare the execution mode
-     get_node()->declare_parameter<std::string>("execution_mode", execution_mode_);
+    get_node()->declare_parameter<std::string>("execution_mode", execution_mode_);
 
     return controller_interface::CallbackReturn::SUCCESS;
   }
@@ -117,13 +116,15 @@ namespace cobot_trajectory_controller
     {
       // handle execution modes
       get_node()->get_parameter("execution_mode", execution_mode_);
-      if (execution_mode_ == "full_trajectory"){
-        // we need to reduce the number of points of the trajectory so the 
+      if (execution_mode_ == "full_trajectory")
+      {
+        // we need to reduce the number of points of the trajectory so the
         // hardware interface can handle the list execution
         auto resampled_trajectory = resample_trajectory(full_trajectory->value());
         external_trajectory_buffer_->writeFromNonRT(resampled_trajectory);
       }
-      else if(execution_mode_ == "single_point"){
+      else if (execution_mode_ == "single_point")
+      {
         trajectory_msgs::msg::JointTrajectory single_point_trajectory;
         single_point_trajectory.header.stamp = full_trajectory->value().header.stamp;
         single_point_trajectory.joint_names = full_trajectory->value().joint_names;
@@ -132,9 +133,10 @@ namespace cobot_trajectory_controller
         single_point_trajectory.points.push_back(last_trajectory_point);
         external_trajectory_buffer_->writeFromNonRT(single_point_trajectory);
       }
-      else {
+      else
+      {
         RCLCPP_ERROR(*local_logger_, "Invalid execution mode. Set execution_mode parameter to single_point or full_trajectory and reset controller.");
-          return controller_interface::return_type::ERROR;
+        return controller_interface::return_type::ERROR;
       }
 
       // reset the buffer
@@ -155,14 +157,17 @@ namespace cobot_trajectory_controller
     // TODO @rharbach: implement a more complex approach using linear interpolation
     const auto kUseEveryNthTrajectoryPoint = 10;
     trajectory_msgs::msg::JointTrajectory resampled_trajectory;
-    for (size_t i = 0; i < trajectory.points.size(); i++) {
-      if (i ==  trajectory.points.size() - 1) {
+    for (size_t i = 0; i < trajectory.points.size(); i++)
+    {
+      if (i == trajectory.points.size() - 1)
+      {
         // always add last point
-         resampled_trajectory.points.push_back(trajectory.points[i]);
-      }
-      else if(i % kUseEveryNthTrajectoryPoint == 0){
         resampled_trajectory.points.push_back(trajectory.points[i]);
-       }
+      }
+      else if (i % kUseEveryNthTrajectoryPoint == 0)
+      {
+        resampled_trajectory.points.push_back(trajectory.points[i]);
+      }
     }
     return resampled_trajectory;
   }

--- a/src/demo/launch/rviz_demo_launch.py
+++ b/src/demo/launch/rviz_demo_launch.py
@@ -210,13 +210,58 @@ def _setup_nodes(context, *args, **kwargs):
                 {"use_sim_time": use_sim_time},
             ],
         ),
-        # start controllers
+        ### start controllers ###
+        # arm group controller (with fake controls)
         Node(
             package="controller_manager",
             executable="spawner",
             output="log",
-            arguments=["arm_group_controller", "--ros-args", "--log-level", log_level],
+            arguments=[
+                "arm_group_controller",
+                "--ros-args",
+                "--log-level",
+                log_level,
+            ],
             parameters=[{"use_sim_time": use_sim_time}],
+            condition=(
+                IfCondition(
+                    PythonExpression(
+                        [
+                            "'",
+                            controller_type,
+                            "'",
+                            " == ",
+                            "'fake'",
+                        ]
+                    )
+                )
+            ),
+        ),
+        # cobot arm group controller (for real cobot)
+        Node(
+            package="controller_manager",
+            executable="spawner",
+            output="log",
+            arguments=[
+                "cobot_arm_group_controller",
+                "--ros-args",
+                "--log-level",
+                log_level,
+            ],
+            parameters=[{"use_sim_time": use_sim_time}],
+            condition=(
+                IfCondition(
+                    PythonExpression(
+                        [
+                            "'",
+                            controller_type,
+                            "'",
+                            " == ",
+                            "'real'",
+                        ]
+                    )
+                )
+            ),
         ),
         Node(
             package="controller_manager",


### PR DESCRIPTION
Introducing a custom controller that sends out an entire trajectory or the last point of a trajectory to the hardware interface. This package only works with the corresponding version of the `cobot_hardware` package. Refer branch `implement-full-trajectory-hw-interface` of the `cobot_hardware` repo the GitLab.

Communication overview:

```
MoveIt Planning (OMPL) → Generates a collision free path
        ↓
Time Parameterization Plugin (Iterative / TOTG) → Adds time (making it an actual trajectory)
        ↓
Final RobotTrajectory message
        ↓
MoveIt Simple Controller Manager
        ↓
cobot_trajectory_controller (this package)
        ↓ trajectory (via shared buffer)
cobot_hardware
```
