### PR TITLE
devcontainer with persistent bash history

### DIFF
--- a/.devcontainer/bashrc
+++ b/.devcontainer/bashrc
@@ -1,0 +1,18 @@
+# additions to ~/.bashrc
+
+# >>> persistent bash history >>>
+export HISTFILE=~/bash/.bash_history
+touch $HISTFILE
+
+# >>> ROS 2 Setup >>>
+# Adjust the ROS_DISTRO variable to match your installed ROS 2 distro
+# Supported: humble, iron, jazzy (Ubuntu 24.04 likely uses jazzy or iron)
+export ROS_DISTRO=jazzy  # change to 'iron' or 'humble' if needed
+
+# Source ROS 2
+source /opt/ros/$ROS_DISTRO/setup.bash
+
+# Colcon workspace setup (optional)
+if [ -f /workspace/install/setup.bash ]; then
+    source /workspace/install/setup.bash
+fi

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,10 @@
         "--hostname=ros2-vnc-docker",
         "--shm-size=512m",
         "--init",
+        "-v",
+        "./docker/bash:/home/ubuntu/bash",
         "--security-opt",
         "seccomp=unconfined"
-    ]
+    ],
+    "postCreateCommand": "cat .devcontainer/bashrc >> ~/.bashrc"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Created by https://www.toptal.com/developers/gitignore/api/ros2
 # Edit at https://www.toptal.com/developers/gitignore?templates=ros2
 
+# devcontainer persistent bash history
+docker/bash/.bash_history
+
 ### ROS2 ###
 install/
 log/


### PR DESCRIPTION
devcontainer now sources ros2 workspace automatically if existent and bash history is made persistent (even is container is rebuild)