### PR TITLE
123 adapt vacuum gripper extension

### DIFF
--- a/src/cobot_model/urdf/robot_model.urdf.xacro
+++ b/src/cobot_model/urdf/robot_model.urdf.xacro
@@ -567,7 +567,7 @@
         <parent link="tool_base"/>
         <child link="vacuum_gripper_up"/>
         <axis xyz="0 0 1"/>
-        <limit effort="30.0" lower="-0.01" upper="0.036" velocity="0.1"/>
+        <limit effort="30.0" lower="-0.01" upper="0.055" velocity="0.1"/>
     </joint>
     <joint name="vacuum_up_tcp_mount" type="fixed">
         <!-- place TCP at the end of the tool (z-direction) -->
@@ -598,7 +598,7 @@
         <parent link="tool_base"/>
         <child link="vacuum_gripper_down"/>
         <axis xyz="0 0 1"/>
-        <limit effort="30.0" lower="-0.01" upper="0.036" velocity="0.1"/>
+        <limit effort="30.0" lower="-0.01" upper="0.055" velocity="0.1"/>
     </joint>
     <joint name="vacuum_down_tcp_mount" type="fixed">
         <!-- place TCP at the end of the tool (z-direction) -->

--- a/src/cobot_moveit_config/config/festo_cobot_model.srdf
+++ b/src/cobot_moveit_config/config/festo_cobot_model.srdf
@@ -107,8 +107,8 @@
       <joint name="vacuum_down_joint"/>
   </group>
   <group_state name="active" group="vacuum_gripper_group">
-    <joint name="vacuum_up_joint" value="0.035" />
-    <joint name="vacuum_down_joint" value="0.035" />
+    <joint name="vacuum_up_joint" value="0.055" />
+    <joint name="vacuum_down_joint" value="0.055" />
   </group_state>
   <group_state name="inactive" group="vacuum_gripper_group">
     <joint name="vacuum_up_joint" value="0.0" />


### PR DESCRIPTION
Since we have re-modelled the Cobot (refer [PR](https://github.com/robgineer/cobot/pull/120)), the vacuum gripper extentsion is now in $Z$ direction (was in ($X$ and $Z$).

=> this implies that the extraction value has to be updated.

Summary of changes:

1. adapted max values for gripper extension in URDF (joint limits)
2. updated srdf to extract by $0.055$ instead of $0.035$.
3. updated `cobot_hardware` (submodule implementing the hardware interface)

| Before fix | After fix |
|-----------|---------|
| <img width="224" height="278" alt="Screenshot 2025-08-25 at 11 41 35" src="https://github.com/user-attachments/assets/17fb49ae-1f86-4792-8f83-8e8e8b061eb7" /> | <img width="224" height="278" alt="Screenshot 2025-08-25 at 11 07 38" src="https://github.com/user-attachments/assets/019cf35d-312c-4a79-ac75-706c8d18a6b4" /> |
