### PR TITLE
Activate real sense for occupancy map monitor

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get install -y ros-jazzy-ros2-control ros-jazzy-ros2-controllers
 RUN apt-get install -y ros-jazzy-gz-ros2-control
 # install Moveit2
 RUN apt-get install -y ros-jazzy-moveit ros-jazzy-moveit-py ros-jazzy-moveit-ros-control-interface ros-jazzy-control-msgs
-RUN apt-get install -y ros-jazzy-moveit-visual-tools
+RUN apt-get install -y ros-jazzy-moveit-visual-tools ros-jazzy-moveit-ros-perception
 # install panda config (for reference purposes)
 RUN apt-get install -y ros-jazzy-moveit-resources-panda-moveit-config
 # install joint manipulator

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get install -y ros-jazzy-ros2-control ros-jazzy-ros2-controllers
 RUN apt-get install -y ros-jazzy-gz-ros2-control
 # install Moveit2
 RUN apt-get install -y ros-jazzy-moveit ros-jazzy-moveit-py ros-jazzy-moveit-ros-control-interface ros-jazzy-control-msgs
-RUN apt-get install -y ros-jazzy-moveit-visual-tools ros-jazzy-moveit-ros-perception
+RUN apt-get install -y ros-jazzy-moveit-visual-tools
 # install panda config (for reference purposes)
 RUN apt-get install -y ros-jazzy-moveit-resources-panda-moveit-config
 # install joint manipulator
@@ -34,9 +34,9 @@ RUN apt-get install -y ros-jazzy-rqt-joint-trajectory-controller
 RUN apt-get install -y ros-jazzy-py-binding-tools
 # colcon utils
 RUN apt-get install -y python3-colcon-clean python3-colcon-mixin
-# realsense drivers
+# realsense drivers and Moveit2 perception
 RUN apt-get update
-RUN apt-get install -y ros-jazzy-librealsense2*
+RUN apt-get install -y ros-jazzy-librealsense2* ros-jazzy-moveit-ros-perception
 # pyaudio
 RUN apt-get install -y python3-pyaudio
 # marker detection

--- a/src/cobot_moveit_config/config/sensor_3d.yaml
+++ b/src/cobot_moveit_config/config/sensor_3d.yaml
@@ -1,13 +1,13 @@
-octomap_resolution: 0.05
+octomap_resolution: 0.01
 sensors:
   - camera_depth_image
 camera_depth_image:
     sensor_plugin: occupancy_map_monitor/DepthImageOctomapUpdater
     image_topic: /camera/camera/depth/image_rect_raw
     queue_size: 5
-    near_clipping_plane_distance: 0.1
-    far_clipping_plane_distance: 0.2
-    shadow_threshold: 0.9
+    near_clipping_plane_distance: 0.3
+    far_clipping_plane_distance: 1.5
+    shadow_threshold: 0.2
     padding_scale: 1.0
     max_update_rate: 1.0
     filtered_cloud_topic: /depth_camera/filtered_depth

--- a/src/cobot_moveit_config/config/sensor_3d.yaml
+++ b/src/cobot_moveit_config/config/sensor_3d.yaml
@@ -1,0 +1,13 @@
+octomap_resolution: 0.05
+sensors:
+  - camera_depth_image
+camera_depth_image:
+    sensor_plugin: occupancy_map_monitor/DepthImageOctomapUpdater
+    image_topic: /camera/camera/depth/image_rect_raw
+    queue_size: 5
+    near_clipping_plane_distance: 0.1
+    far_clipping_plane_distance: 0.2
+    shadow_threshold: 0.9
+    padding_scale: 1.0
+    max_update_rate: 1.0
+    filtered_cloud_topic: /depth_camera/filtered_depth

--- a/src/demo/launch/rviz_demo_launch.py
+++ b/src/demo/launch/rviz_demo_launch.py
@@ -133,11 +133,13 @@ def _setup_nodes(context, *args, **kwargs):
     )
 
     # load config for occupancy map
-    sensors_yaml = (
+    """ deactivated by default; requires testing on real Cobot """
+    """ sensors_yaml = (
         load_file(moveit_config_package, path.join("config", "sensor_3d.yaml"))
         if enable_realsense_camera
         else {"sensors": []}  # create empty config if camera is not running
-    )
+    ) """
+    sensors_yaml = {"sensors": {}}
 
     # configure trajectory execution
     trajectory_execution = {

--- a/src/demo/launch/rviz_demo_launch.py
+++ b/src/demo/launch/rviz_demo_launch.py
@@ -132,14 +132,11 @@ def _setup_nodes(context, *args, **kwargs):
         "ros2_controllers.yaml",
     )
 
-    # load config for occupancy map
-    """ deactivated by default; requires testing on real Cobot """
-    """ sensors_yaml = (
-        load_file(moveit_config_package, path.join("config", "sensor_3d.yaml"))
-        if enable_realsense_camera
-        else {"sensors": []}  # create empty config if camera is not running
-    ) """
-    sensors_yaml = {"sensors": {}}
+    # load config for occupancy grid
+    """ no used; requires testing on real Cobot """
+    sensors_yaml = load_file(
+        moveit_config_package, path.join("config", "sensor_3d.yaml")
+    )
 
     # configure trajectory execution
     trajectory_execution = {
@@ -196,7 +193,7 @@ def _setup_nodes(context, *args, **kwargs):
                 moveit_controllers_yaml,
                 {"use_sim_time": use_sim_time},
                 move_group_capabilities,
-                sensors_yaml,
+                # sensors_yaml, # inactive (occupancy grid requires testing)
             ],
         ),
         # rviz2

--- a/src/demo/launch/rviz_demo_launch.py
+++ b/src/demo/launch/rviz_demo_launch.py
@@ -337,6 +337,7 @@ def _setup_nodes(context, *args, **kwargs):
             ),
             launch_arguments={
                 "pointcloud.enable": "true",
+                "clip_distance": "1.3",
             }.items(),
             condition=(
                 IfCondition(

--- a/src/demo/launch/rviz_demo_launch.py
+++ b/src/demo/launch/rviz_demo_launch.py
@@ -132,6 +132,13 @@ def _setup_nodes(context, *args, **kwargs):
         "ros2_controllers.yaml",
     )
 
+    # load config for occupancy map
+    sensors_yaml = (
+        load_file(moveit_config_package, path.join("config", "sensor_3d.yaml"))
+        if enable_realsense_camera
+        else {"sensors": []}  # create empty config if camera is not running
+    )
+
     # configure trajectory execution
     trajectory_execution = {
         "allow_trajectory_execution": True,
@@ -187,6 +194,7 @@ def _setup_nodes(context, *args, **kwargs):
                 moveit_controllers_yaml,
                 {"use_sim_time": use_sim_time},
                 move_group_capabilities,
+                sensors_yaml,
             ],
         ),
         # rviz2


### PR DESCRIPTION
Enabling the occupancy grid in MoveIt2

=> deactivated for now due to required testing with the real Cobot.

## Summary of changes

### 1. Added sensors config and passed in demo lauchfile

### 2. Changed depth of real-sense node to $1.3$ [m].

Otherwise the occupancy grip shows the entire room.

Before change:

<img width="447" height="322" alt="Screenshot 2025-09-02 at 11 48 58" src="https://github.com/user-attachments/assets/c1b2aba8-988d-4387-bb79-e57b6d37d500" />


After change:
<img width="400" height="400" alt="Screenshot 2025-09-02 at 17 20 37" src="https://github.com/user-attachments/assets/9dc6fb57-a1ad-4d4f-932d-73feba362778" />


## Observations

### 1. There are several misalignments around the Cobot:
The Cobot is not in its `home_pose` but twisted around joints 2 and 3 and in collision (the safe state) => cannot move the joints into the preferred pose. 

The camera and the Cobot are misaligned. Example:

<img width="300" height="300" alt="Screenshot 2025-09-03 at 11 09 37" src="https://github.com/user-attachments/assets/f1d3aad0-a504-4980-81bc-0a58fc41d84d" />

... which leads to this
<img width="300" height="200" alt="Screenshot 2025-09-03 at 11 11 46" src="https://github.com/user-attachments/assets/f96bba61-b9a8-45e2-b244-cde12444fc5e" />

#### Origin of issue
The state publisher and the real Cobot do not have the same information. Need to test this on the Cobot with real controls active.

@td-code this might require refinement / has to be tested on the Cobot.

### 2.  Meshes are not filtered 

On startup: the `DepthImageOctomapUpdater` does not seem to be able to filter out the model meshes.
```
[move_group.moveit.moveit.ros.depth_image_octomap_updater]: Internal error. Mesh filter handle <n> not found
```
 we can see in the `/model_depth` topic (probably resulting from the mismatch between the state publisher and the real Cobot):

<img width="366" height="267" alt="Screenshot 2025-09-02 at 11 51 43" src="https://github.com/user-attachments/assets/f72d6d83-5772-46a5-ad06-6072658b1b8c" />




